### PR TITLE
enabled no bad blocks and indentation for eslint/jsdoc

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -28,7 +28,7 @@ module.exports = {
     'jsdoc/check-access': 1, // Recommended
     'jsdoc/check-alignment': 1, // Recommended
     // 'jsdoc/check-examples': 1,
-    // 'jsdoc/check-indentation': 1,
+    'jsdoc/check-indentation': 1,
     // 'jsdoc/check-line-alignment': 1,
     'jsdoc/check-param-names': 1, // Recommended
     'jsdoc/check-property-names': 1, // Recommended
@@ -41,7 +41,7 @@ module.exports = {
     // 'jsdoc/informative-docs': 1,
     // 'jsdoc/match-description': 1,
     'jsdoc/multiline-blocks': 1, // Recommended
-    // 'jsdoc/no-bad-blocks': 1,
+    'jsdoc/no-bad-blocks': 1,
     // 'jsdoc/no-blank-block-descriptions': 1,
     // 'jsdoc/no-defaults': 1,
     // 'jsdoc/no-missing-syntax': 1,


### PR DESCRIPTION
This PR fixes #11 