### PR TITLE
DRAFT: Feature/vc service integration

### DIFF
--- a/scripts/configure-pods.sh
+++ b/scripts/configure-pods.sh
@@ -3,3 +3,5 @@
 copyfiles -u 1 -a "initial-pod-data/**/*" pods/example
 copyfiles -u 4 test/assets/webIdProfiles/noOidcIsser/* pods/example2/profile/
 copyfiles -u 4 test/assets/webIdProfiles/invalidWebId/* pods/invalidWebId/profile/
+cp  test/assets/webIdProfiles/verifiable-example/profile/* pods/verifiable-example/profile/
+cp  test/assets/webIdProfiles/verifiable-example/data/* pods/verifiable-example/

--- a/seeded-pod-config.json
+++ b/seeded-pod-config.json
@@ -13,5 +13,10 @@
     "podName": "invalidWebId",
     "email": "badRdf@example.com",
     "password": "rdf123"
+  },
+  {
+    "podName": "verifiable-example",
+    "email": "hello@verifiable-example.com",
+    "password": "abc123"
   }
 ]

--- a/src/config.json
+++ b/src/config.json
@@ -182,6 +182,20 @@
         ],
         "lenient": true
       }
+    },
+    {
+      "queryLocation": "components.rq",
+      "name": "Verifiable Components",
+      "description": "Components are queried from three kinds of sources: a non-verifiable source, a successfully verifiable source, and a verifiable source with an incorrect proof.",
+      "id": "7002",
+      "comunicaContext": {
+        "sources": [
+          "http://localhost:8080/example/components",
+          "http://localhost:8080/verifiable-example/components-vc",
+          "http://localhost:8080/verifiable-example/components-vc-incorrect-proof"
+        ],
+        "lenient": true
+      }
     }
   ]
 }

--- a/test/assets/webIdProfiles/verifiable-example/data/components-vc$.jsonld
+++ b/test/assets/webIdProfiles/verifiable-example/data/components-vc$.jsonld
@@ -1,0 +1,87 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://w3id.org/security/data-integrity/v2"
+  ],
+  "type": [
+    "VerifiableCredential"
+  ],
+  "issuer": "http://localhost:8080/verifiable-example/profile/card#me",
+  "issuanceDate": "2024-03-27T12:42:07Z",
+  "credentialSubject": [
+    {
+      "@id": "http://www/example.com/data/component-c01",
+      "@type": [
+        "http://www/example.com/ont/Component"
+      ],
+      "http://www/example.com/ont/has-component-bom": [
+        {
+          "@id": "http://www/example.com/data/component-bom-b01"
+        }
+      ],
+      "http://www/example.com/ont/name": [
+        {
+          "@value": "Component 1"
+        }
+      ],
+      "http://www/example.com/ont/recycled-content-percentage": [
+        {
+          "@value": "80",
+          "@type": "http://www.w3.org/2001/XMLSchema#integer"
+        }
+      ]
+    },
+    {
+      "@id": "http://www/example.com/data/component-c02",
+      "@type": [
+        "http://www/example.com/ont/Component"
+      ],
+      "http://www/example.com/ont/has-component-bom": [
+        {
+          "@id": "http://www/example.com/data/component-bom-b02"
+        }
+      ],
+      "http://www/example.com/ont/name": [
+        {
+          "@value": "Component 2"
+        }
+      ],
+      "http://www/example.com/ont/recycled-content-percentage": [
+        {
+          "@value": "20",
+          "@type": "http://www.w3.org/2001/XMLSchema#integer"
+        }
+      ]
+    },
+    {
+      "@id": "http://www/example.com/data/component-c03",
+      "@type": [
+        "http://www/example.com/ont/Component"
+      ],
+      "http://www/example.com/ont/has-component-bom": [
+        {
+          "@id": "http://www/example.com/data/component-bom-b03"
+        }
+      ],
+      "http://www/example.com/ont/name": [
+        {
+          "@value": "Component 3"
+        }
+      ],
+      "http://www/example.com/ont/recycled-content-percentage": [
+        {
+          "@value": "0",
+          "@type": "http://www.w3.org/2001/XMLSchema#integer"
+        }
+      ]
+    }
+  ],
+  "proof": {
+    "type": "DataIntegrityProof",
+    "created": "2024-03-27T12:42:07Z",
+    "verificationMethod": "http://localhost:8080/verifiable-example/profile/key",
+    "cryptosuite": "eddsa-2022",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "z3WW59zMuThFU26BKaUm3XXnFijFob7s3gb2ig1cVKahNUNh5ytfQhJ5KnpQ8wacMfFZnDpSBUwhhQuyfcEfR6MeK"
+  }
+}

--- a/test/assets/webIdProfiles/verifiable-example/data/components-vc-incorrect-proof$.jsonld
+++ b/test/assets/webIdProfiles/verifiable-example/data/components-vc-incorrect-proof$.jsonld
@@ -1,0 +1,87 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://w3id.org/security/data-integrity/v2"
+  ],
+  "type": [
+    "VerifiableCredential"
+  ],
+  "issuer": "http://localhost:8080/verifiable-example/profile/card#me",
+  "issuanceDate": "2024-03-27T12:42:07Z",
+  "credentialSubject": [
+    {
+      "@id": "http://www/example.com/data/component-c01",
+      "@type": [
+        "http://www/example.com/ont/Component"
+      ],
+      "http://www/example.com/ont/has-component-bom": [
+        {
+          "@id": "http://www/example.com/data/component-bom-b01"
+        }
+      ],
+      "http://www/example.com/ont/name": [
+        {
+          "@value": "Component 1"
+        }
+      ],
+      "http://www/example.com/ont/recycled-content-percentage": [
+        {
+          "@value": "80",
+          "@type": "http://www.w3.org/2001/XMLSchema#integer"
+        }
+      ]
+    },
+    {
+      "@id": "http://www/example.com/data/component-c02",
+      "@type": [
+        "http://www/example.com/ont/Component"
+      ],
+      "http://www/example.com/ont/has-component-bom": [
+        {
+          "@id": "http://www/example.com/data/component-bom-b02"
+        }
+      ],
+      "http://www/example.com/ont/name": [
+        {
+          "@value": "Component 2"
+        }
+      ],
+      "http://www/example.com/ont/recycled-content-percentage": [
+        {
+          "@value": "20",
+          "@type": "http://www.w3.org/2001/XMLSchema#integer"
+        }
+      ]
+    },
+    {
+      "@id": "http://www/example.com/data/component-c03",
+      "@type": [
+        "http://www/example.com/ont/Component"
+      ],
+      "http://www/example.com/ont/has-component-bom": [
+        {
+          "@id": "http://www/example.com/data/component-bom-b03"
+        }
+      ],
+      "http://www/example.com/ont/name": [
+        {
+          "@value": "Component 3"
+        }
+      ],
+      "http://www/example.com/ont/recycled-content-percentage": [
+        {
+          "@value": "0",
+          "@type": "http://www.w3.org/2001/XMLSchema#integer"
+        }
+      ]
+    }
+  ],
+  "proof": {
+    "type": "DataIntegrityProof",
+    "created": "2024-03-27T12:42:07Z",
+    "verificationMethod": "http://localhost:8080/verifiable-example/profile/key",
+    "cryptosuite": "eddsa-2022",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "incorrect-proof!"
+  }
+}

--- a/test/assets/webIdProfiles/verifiable-example/data/components-vc-incorrect-proof.acl
+++ b/test/assets/webIdProfiles/verifiable-example/data/components-vc-incorrect-proof.acl
@@ -1,0 +1,14 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+
+<#public>
+    a acl:Authorization;
+    acl:accessTo <./components-vc-incorrect-proof>;
+    acl:agentClass foaf:Agent;
+    acl:mode acl:Read.
+
+<#owner>
+    a acl:Authorization;
+        acl:accessTo <./components-vc-incorrect-proof>;
+    acl:agent <http://localhost:8080/verifiable-example/profile/card#me>;
+    acl:mode acl:Read, acl:Write, acl:Control.

--- a/test/assets/webIdProfiles/verifiable-example/data/components-vc.acl
+++ b/test/assets/webIdProfiles/verifiable-example/data/components-vc.acl
@@ -1,0 +1,14 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+
+<#public>
+    a acl:Authorization;
+    acl:accessTo <./components-vc>;
+    acl:agentClass foaf:Agent;
+    acl:mode acl:Read.
+
+<#owner>
+    a acl:Authorization;
+    acl:accessTo <./components-vc>;
+    acl:agent <http://localhost:8080/verifiable-example/profile/card#me>;
+    acl:mode acl:Read, acl:Write, acl:Control.

--- a/test/assets/webIdProfiles/verifiable-example/profile/card$.ttl
+++ b/test/assets/webIdProfiles/verifiable-example/profile/card$.ttl
@@ -1,0 +1,10 @@
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix solid: <http://www.w3.org/ns/solid/terms#>.
+
+<http://localhost:8080/verifiable-example/profile/card> a foaf:PersonalProfileDocument;
+    foaf:maker <#me>;
+    foaf:primaryTopic <#me>.
+<#me> a foaf:Person;
+    solid:oidcIssuer <http://localhost:8080/>;
+    <https://w3id.org/security#assertionMethod> <http://localhost:8080/verifiable-example/profile/key>;
+    <https://w3id.org/security#verificationMethod> <http://localhost:8080/verifiable-example/profile/key>.

--- a/test/assets/webIdProfiles/verifiable-example/profile/card.acl
+++ b/test/assets/webIdProfiles/verifiable-example/profile/card.acl
@@ -1,0 +1,19 @@
+# ACL resource for the WebID profile document
+@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+
+# The WebID profile is readable by the public.
+# This is required for discovery and verification,
+# e.g. when checking identity providers.
+<#public>
+    a acl:Authorization;
+    acl:agentClass foaf:Agent;
+    acl:accessTo <./card>;
+    acl:mode acl:Read.
+
+# The owner has full access to the profile
+<#owner>
+    a acl:Authorization;
+    acl:agent <http://localhost:8080/verifiable-example/profile/card#me>;
+    acl:accessTo <./card>;
+    acl:mode acl:Read, acl:Write, acl:Control.

--- a/test/assets/webIdProfiles/verifiable-example/profile/key$.json
+++ b/test/assets/webIdProfiles/verifiable-example/profile/key$.json
@@ -1,0 +1,7 @@
+{
+  "@context": "https://w3id.org/security/multikey/v1",
+  "id": "http://localhost:8080/verifiable-example/profile/key",
+  "type": "Multikey",
+  "controller": "http://localhost:8080/verifiable-example/profile/card#me",
+  "publicKeyMultibase": "z6MkhjfxuFhkoqjxwQeyodmqX4cwu4xewwkK7pW1jnWBvSFL"
+}

--- a/test/assets/webIdProfiles/verifiable-example/profile/key.acl
+++ b/test/assets/webIdProfiles/verifiable-example/profile/key.acl
@@ -1,0 +1,9 @@
+<http://localhost:8080/verifiable-example/.acl#owner> a <http://www.w3.org/ns/auth/acl#Authorization>;
+    <http://www.w3.org/ns/auth/acl#agent> <http://localhost:8080/verifiable-example/profile/card#me>;
+    <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read>, <http://www.w3.org/ns/auth/acl#Write>, <http://www.w3.org/ns/auth/acl#Control>;
+    <http://www.w3.org/ns/auth/acl#accessTo> <http://localhost:8080/verifiable-example/profile/key>;
+    <http://www.w3.org/ns/auth/acl#default> <http://localhost:8080/verifiable-example/profile/key>.
+<#cfd90b5d-d315-42cd-8938-bee0981bd530> a <http://www.w3.org/ns/auth/acl#Authorization>;
+    <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read>;
+    <http://www.w3.org/ns/auth/acl#accessTo> <http://localhost:8080/verifiable-example/profile/key>;
+    <http://www.w3.org/ns/auth/acl#agentClass> <http://xmlns.com/foaf/0.1/Agent>.


### PR DESCRIPTION
Fixes #92

---

TODOs
- [ ] Publish `vc-service`
- [ ] How should we test this verification feature?

# Description

To separate concerns, the verification of a data source depends on an external service providing functionality for:
i) setting up a Solid Pod with a cryptographic key pair (`<vc-service>/setup`);
ii) issue Verifiable Credentials (`<vc-service>/issue`); and
iii) verifying a VC (`<vc-service>/verify`).

In this PR, the following changes are made:
- Clicking the question mark of a data source executes a verify-request on the `vc-service`.
- Depending on the verification response, a source's verification symbol will indicate that the source
  - Is not verifiable (i.e.,the data source is not a Verifiable Credential) (cfr. 1st screenshot - source: `http://localhost:8080/example/components`- `VerifiedUserIcon`)
  - Is verified (i.e., proof matched) (cfr. 1st screenshot - source: `http://localhost:8080/verifiable-example/components-vc` - `VerifiedUserIcon`)
  - Is not verified (i.e., proof did not match) (cfr. 1st screenshot - source: `http://localhost:8080/verifiable-example/components-vc-incorrect-proof` - `GppBadIcon`)
  - Could not be verified due to an error (e.g., when the `vc-service` is unreachable) (cfr. 2nd screenshot - `WarningIcon`)

Screenshot 1
<img width="1114" alt="Scherm­afbeelding 2024-03-27 om 22 33 37" src="https://github.com/SolidLabResearch/generic-data-viewer-react-admin/assets/9964105/5e055a75-8bcb-4bf8-a479-c040309e9663">

Screenshot 2
<img width="1125" alt="Scherm­afbeelding 2024-03-27 om 22 34 01" src="https://github.com/SolidLabResearch/generic-data-viewer-react-admin/assets/9964105/7bcaa235-45f9-4605-8b33-5ff740d568e0">

