### PR TITLE
For logged in users not having a username, the webID is displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+### Changed
+
+- For logged in users not having a username, the webID is displayed (#133).
+
+### Fixed
+
 ## [1.2.1] - 2024-06-17
 
 ### Added

--- a/src/authenticationProvider/authenticationProvider.js
+++ b/src/authenticationProvider/authenticationProvider.js
@@ -79,7 +79,7 @@ export default {
       const dataSet = await getProfileAll(webId, { fetch: fetch });
       const profile = dataSet.webIdProfile;
       const webIdThing = getThing(profile, webId);
-      identity.fullName = getName(webIdThing);
+      identity.fullName = getName(webIdThing) || webIdThing.url;
       identity.avatar = getProfilePicture(webIdThing);
     } catch (error) {
       return identity;
@@ -121,8 +121,6 @@ function getName(webIdThing) {
   const literalName = getLiteral(webIdThing, FOAF.name);
   if (literalName) {
     return literalName.value;
-  } else {
-    return "Username not given";
   }
 }
 


### PR DESCRIPTION
Fixes #133.