### PR TITLE
Fixed clean query cache button functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Solved console warning when hovering over source verification question mark (#128).
 - ASK query is working now (#22).
 - "Finished in" now shows effective query execution time (#130).
+- "Clean query cache" button's functionality works as expected now (#190).
 
 ## [1.6.0] - 2025-03-17
 

--- a/main/src/components/InteractionLayout/NavigationBar/NavigationBar.jsx
+++ b/main/src/components/InteractionLayout/NavigationBar/NavigationBar.jsx
@@ -23,9 +23,9 @@ function AboutButton(props) {
 
 function InvalidateButton() {
   const refresh = useRefresh();
-  const handleClick = () => {
-    comunicaEngineWrapper.reset();
-    setTimeout(refresh, 2000);
+  const handleClick = async () => {
+    await comunicaEngineWrapper.reset();
+    refresh();
   }
   return (
     <Tooltip title="Clean Query Cache">

--- a/main/src/comunicaEngineWrapper/comunicaEngineWrapper.js
+++ b/main/src/comunicaEngineWrapper/comunicaEngineWrapper.js
@@ -27,9 +27,9 @@ class ComunicaEngineWrapper {
   /**
    * Resets the engines and all we maintained here about executed queries
    */
-  reset() {
-    this._engine.invalidateHttpCache();
-    this._engineLinkTraversal.invalidateHttpCache();
+  async reset() {
+    await this._engine.invalidateHttpCache();
+    await this._engineLinkTraversal.invalidateHttpCache();
     this._fetchSuccess = {};
     this._fetchStatusNumber = {};
     this._underlyingFetchFunction = undefined;
@@ -107,7 +107,7 @@ class ComunicaEngineWrapper {
           break;
       }
     } catch (error) {
-      this.reset();
+      await this.reset();
       throw error;
     }
   }
@@ -143,7 +143,7 @@ class ComunicaEngineWrapper {
       this._prepareQuery(context);
       return engine.queryBindings(queryText, context);
     } catch (error) {
-      this.reset();
+      await this.reset();
       throw error;
     }
   }


### PR DESCRIPTION
Fixes #190.

Note that the functionality was already "almost" fixed as a result of the previous pull request.
Now however, the button also correctly executes a display refresh after clearing the query cache.