### PR TITLE
Avoided (infinite) display of "The list is loading. Just a moment please."...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - configs/oslo-kg: use smaller datasets for queries.
 - React-admin version updated to 5.7.2 (#207).
 
+### Fixed
+
+- Avoided (infinite) display of "The list is loading. Just a moment please." for queries that should show "The result list is empty.", in cases where the user does not have the right to read the involved source(s) (#209).
+
 ## [1.7.0] - 2025-04-09
 
 ### Added

--- a/main/src/comunicaEngineWrapper/comunicaEngineWrapper.js
+++ b/main/src/comunicaEngineWrapper/comunicaEngineWrapper.js
@@ -79,27 +79,31 @@ class ComunicaEngineWrapper {
             callbacks["variables"](variables);
           }
           const bindingsStream = await result.execute();
-          await new Promise((resolve, reject) => {
-            if (callbacks["bindings"]) {
-              bindingsStream.on('data', (bindings) => {
-                callbacks["bindings"](bindings);
-              });
-            }
-            bindingsStream.on('end', resolve);
-            bindingsStream.on('error', reject);
-          });
+          if (!bindingsStream.done) {
+            await new Promise((resolve, reject) => {
+              if (callbacks["bindings"]) {
+                bindingsStream.on('data', (bindings) => {
+                  callbacks["bindings"](bindings);
+                });
+              }
+              bindingsStream.on('end', resolve);
+              bindingsStream.on('error', reject);
+            });
+          }
           break;
         case 'quads':
           const quadStream = await result.execute();
-          await new Promise((resolve, reject) => {
-            if (callbacks["quads"]) {
-              quadStream.on('data', (quad) => {
-                callbacks["quads"](quad);
-              });
-            }
-            quadStream.on('end', resolve);
-            quadStream.on('error', reject);
-          });
+          if (!bindingsStream.done) {
+            await new Promise((resolve, reject) => {
+              if (callbacks["quads"]) {
+                quadStream.on('data', (quad) => {
+                  callbacks["quads"](quad);
+                });
+              }
+              quadStream.on('end', resolve);
+              quadStream.on('error', reject);
+            });
+          }
           break;
         case 'boolean':
           const answer = await result.execute();


### PR DESCRIPTION
...  for queries that should show "The result list is empty.", in cases where the user does not have the right to read the involved source(s).

Fixes #209.

In some cases (not our test case, but the query mentioned in the issue is a not easy to replicate example), the stream returned by Comunica is already "done" before we can attach our listeners. So, checking its done status is the solution.